### PR TITLE
Fixes memory corruption crash when using non-square patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 wiki/
+EMSphinxBuild/

--- a/include/modality/ebsd/pattern.hpp
+++ b/include/modality/ebsd/pattern.hpp
@@ -465,6 +465,7 @@ namespace emsphinx {
 					if     ("EDAX"     == vendor) vendorFlip = true ;
 					else if("Oxford"   == vendor) vendorFlip = false;
 					else if("Bruker"   == vendor) vendorFlip = false;
+					else if("Bruker Nano" == vendor) vendorFlip = false;//h5 files from BCF -> H5 converter software
 					else if("DREAM.3D" == vendor) vendorFlip = false;
 					else if("EMsoft"   == vendor) vendorFlip = true;
 					else throw std::runtime_error("unknown EBSD vendor: " + vendor);

--- a/include/modality/ebsd/pattern.hpp
+++ b/include/modality/ebsd/pattern.hpp
@@ -766,25 +766,37 @@ namespace emsphinx {
 			   0xFF != header[6] ||
 			   0xFF != header[7]) throw std::runtime_error("unexpected header for " + name);//check header
 			if(!ifs.read((char*)&offset, sizeof(offset))) throw std::runtime_error("failed to read first pattern position from " + name);//read offset to first pattern
-			const size_t numPat = size_t( (offset - 8) / 8 );//compute pattern count from offset to first pattern
+
+			//ISSUE! Order of offset values is only APPROXIMATELY linear, sometimes they are "out of order". 
+			//Old code crashes if first offset is not first pattern; commented this out.
+			//Shifted pattern header read block earlier to allow reliable numPats calculation from file size and pattern size.
+
+			//Seek to the first pattern and get some info
+			//each pattern block has a 16 byte header, some (maybe 0) padding space, the pattern, and then 18 tail bytes:
+			// uint8_t x position
+			// double  x position (in microns)
+			// uint8_t y position
+			// double  y position (in microns)
+			ifs.seekg(offset);
+			uint32_t leadIn, width, height, bytes;
+			if (!ifs.read((char*)&leadIn, sizeof(uint32_t))) throw std::runtime_error("failed to read lead in of first pattern in " + name);
+			if (!ifs.read((char*)&height, sizeof(uint32_t))) throw std::runtime_error("failed to read width of first pattern in " + name);
+			if (!ifs.read((char*)&width, sizeof(uint32_t))) throw std::runtime_error("failed to read height of first pattern in " + name);
+			if (!ifs.read((char*)&bytes, sizeof(uint32_t))) throw std::runtime_error("failed to read bytes of first pattern in " + name);
+
+			//experimental code below
+			ifs.seekg(0, std::ios::end);
+			const size_t fsize = ifs.tellg();
+			//each pattern has 8 byte offset, 16 byte header, and 18 byte footer = 42 bytes + pattern bytes
+			const size_t numPat = size_t(fsize / (bytes + 42));//compute pattern count from file size
 
 			//now read all the offsets at once
 			ifs.seekg(8);//go back to first index
 			std::vector<uint64_t> offsets(numPat);//save space to hold all offsets
 			if(!ifs.read((char*)offsets.data(), sizeof(uint64_t) * offsets.size())) throw std::runtime_error("failed to read offsets from " + name);
 
-			//next seek to the first pattern and get some info
-			//each pattern block has a 16 byte header, some (maybe 0) padding space, the pattern, and then 18 tail bytes:
-			// uint8_t x position
-			// double  x position (in microns)
-			// uint8_t y position
-			// double  y position (in microns)
-			ifs.seekg(offsets[0]);
-			uint32_t leadIn, width, height, bytes;
-			if(!ifs.read((char*)&leadIn, sizeof(uint32_t))) throw std::runtime_error("failed to read lead in of first pattern in " + name);
-			if(!ifs.read((char*)&height, sizeof(uint32_t))) throw std::runtime_error("failed to read width of first pattern in " + name);
-			if(!ifs.read((char*)&width , sizeof(uint32_t))) throw std::runtime_error("failed to read height of first pattern in " + name);
-			if(!ifs.read((char*)&bytes , sizeof(uint32_t))) throw std::runtime_error("failed to read bytes of first pattern in " + name);
+			//now that we have ALL offsets, make sure "offset" is actually the lowest value from them
+			offset = *std::min_element(offsets.begin(), offsets.end());
 
 			//parse the bit depth
 			Bits bits;

--- a/include/modality/ebsd/pattern.hpp
+++ b/include/modality/ebsd/pattern.hpp
@@ -327,6 +327,7 @@ namespace emsphinx {
 							if(!is.read((char*)&hexFlg, sizeof(int8_t )    )) throw std::runtime_error("failed to read UP grid type flag" );
 							if(!is.read((char*) scnRes, sizeof(double ) * 2)) throw std::runtime_error("failed to read UP scan resolution");
 						break;
+						case 4: break;//crude hack - pretend v4 UP-file format associated with APEX is v1 format. Ignore extra header data and only use square scans.
 
 						default: throw std::runtime_error("unsupported UP file version");
 					}

--- a/include/util/ahe.hpp
+++ b/include/util/ahe.hpp
@@ -146,7 +146,7 @@ void AdaptiveHistogramEqualizer<Real, TPix>::setSize(const size_t w, const size_
 	}
 
 	//compute y interpolation once
-	jInds.resize(w);
+	jInds.resize(h);
 	for(size_t j = 0; j < h; j++) {
 		const size_t u = std::distance(jMids.cbegin(), std::upper_bound(jMids.cbegin(), jMids.cend(), j));
 		if(jMids.size() == u) {//beyond last grid point
@@ -166,7 +166,7 @@ void AdaptiveHistogramEqualizer<Real, TPix>::setSize(const size_t w, const size_
 	}
 
 	//compute x interpolation once
-	iInds.resize(h);
+	iInds.resize(w);
 	for(size_t i = 0; i < w; i++) {
 		const size_t u = std::distance(iMids.cbegin(), std::upper_bound(iMids.cbegin(), iMids.cend(), i));
 		if(iMids.size() == u) {//beyond last grid point

--- a/include/wx/MPConvertDlg.h
+++ b/include/wx/MPConvertDlg.h
@@ -97,6 +97,12 @@ MpConvertDialog::MpConvertDialog( wxWindow* parent, wxWindowID id, const wxStrin
 	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
 
 	valBw.SetRange(64, 512);
+	/*
+	Unwanted behavior here! If this is active and the text entry field is blank, numbers cannot be typed in.
+	This is because any single-digit value (0-9) is below the minimum value allowed and will therefore be rejected.
+	While typing in a number will not work, copying and pasting a value will work - including for values outside of the allowed range.
+	Not sure how this reacts to the above, so I simply removed it from line 126 instead. I still don't recommend going below 64 or above ~1000.
+	*/
 
 	wxFlexGridSizer* fgSizer = new wxFlexGridSizer( 7, 2, 0, 0 );
 	fgSizer->AddGrowableCol( 1 );
@@ -118,7 +124,7 @@ MpConvertDialog::MpConvertDialog( wxWindow* parent, wxWindowID id, const wxStrin
 	m_txtForm = new wxTextCtrl      ( this, wxID_ANY, wxT("Unknown"), wxDefaultPosition, wxDefaultSize, 0        );
 	m_txtName = new wxTextCtrl      ( this, wxID_ANY, wxEmptyString , wxDefaultPosition, wxDefaultSize, 0        );
 	m_txtSSyb = new wxTextCtrl      ( this, wxID_ANY, wxEmptyString , wxDefaultPosition, wxDefaultSize, 0        );
-	m_txtBw   = new wxTextCtrl      ( this, wxID_ANY, wxT("384"    ), wxDefaultPosition, wxDefaultSize, 0, valBw );
+	m_txtBw   = new wxTextCtrl      ( this, wxID_ANY, wxT("384"    ), wxDefaultPosition, wxDefaultSize, 0        );
 	m_fileOut = new wxFilePickerCtrl( this, wxID_ANY, wxEmptyString , wxT("Output Master Pattern"), wxT("*.sht"), wxDefaultPosition, wxDefaultSize, wxFLP_OVERWRITE_PROMPT|wxFLP_SAVE|wxFLP_SMALL|wxFLP_USE_TEXTCTRL );
 
 	m_button = new wxButton( this, wxID_ANY, wxT("Convert"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -342,8 +348,8 @@ void MpConvertDialog::OnInputChanged  ( wxFileDirPickerEvent& event ) {
 	//if we made it this far we were able to parse a formula, fill in, set default bandwidth, and set output file
 	wxFileName fn = event.GetPath();
 	fn.SetExt("sht");
-	m_txtForm->ChangeValue(ss.str());
-	m_txtBw->ChangeValue("384");
+	m_txtForm->ChangeValue(ss.str());//Overrides any manual formula input with formula constructed from EMsoft master pattern data file.
+	//m_txtBw->ChangeValue("384");//Overrides any manual conversion bandwidth input with fixed value. Commented out to allow GUI selection of conversion BW.
 	m_fileOut->SetFileName(fn);
 	m_button->Enable(true);
 }


### PR DESCRIPTION
Quick fix for an issue I discovered while trying to get EMSphinx working with some of my data. Didn't show up with the initial patterns I tested (which had the same number of pixels in width and height), since the swapped variables had the same value anyway. 

Cheers,
Greg Sparks